### PR TITLE
使用 os.path.join 统一路径拼接，提升跨平台兼容性

### DIFF
--- a/app/views/SampleView.py
+++ b/app/views/SampleView.py
@@ -304,7 +304,13 @@ def api_postDel(request):
         if len(sample) > 0:
             sample = sample[0]
 
-            new_filename_abs = "%s/task/%s/sample/%s" % (g_config.storageDir, sample.task_code, sample.new_filename)
+            new_filename_abs = os.path.join(
+                g_config.storageDir, 
+                'task', 
+                sample.task_code, 
+                'sample', 
+                sample.new_filename
+            )
             if os.path.exists(new_filename_abs):
                 os.remove(new_filename_abs)
             sample.delete()

--- a/app/views/TaskView.py
+++ b/app/views/TaskView.py
@@ -243,7 +243,7 @@ def api_postDel(request):
             if not g_database.execute(del_sql):
                 g_logger.error("del_sql=%s" % del_sql)
 
-            task_dir = "%s/task/%s" % (g_config.storageDir, task_code)
+            task_dir = os.path.join(g_config.storageDir, "task", task_code)
             try:
                 if os.path.exists(task_dir):
                     shutil.rmtree(task_dir)

--- a/app/views/TrainTestView.py
+++ b/app/views/TrainTestView.py
@@ -23,8 +23,8 @@ def api_postDel(request):
         if len(test) > 0:
             test = test[0]
             # 训练根目录
-            train_dir = "%s/train/%s" % (g_config.storageDir, test.train_code)
-            test_save_dir = "%s/test/%s"%(train_dir,test_code)
+            train_dir = os.path.join(g_config.storageDir, "train", test.train_code)
+            test_save_dir = os.path.join(g_config.storageDir, "test", test_code)
             try:
                 if os.path.exists(test_save_dir):
                     shutil.rmtree(test_save_dir)
@@ -60,7 +60,7 @@ def api_postAdd(request):
                 raise Exception("该训练任务不存在！")
 
             # 训练根目录
-            train_dir = "%s/train/%s" % (g_config.storageDir, train.code)
+            train_dir = os.path.join(g_config.storageDir, "train", train.code)
             if not os.path.exists(train_dir):
                 os.makedirs(train_dir)
 
@@ -73,7 +73,7 @@ def api_postAdd(request):
                 raise Exception("请选择上传文件！")
 
             test_code = "test" + datetime.now().strftime("%Y%m%d%H%M%S") + str(random.randint(1000, 9999))  # 随机生成一个测试编号
-            test_save_dir = "%s/test/%s"%(train_dir,test_code)
+            test_save_dir = os.path.join(train_dir, "test", test_code)
             if not os.path.exists(test_save_dir):
                 os.makedirs(test_save_dir)
 

--- a/app/views/TrainView.py
+++ b/app/views/TrainView.py
@@ -184,7 +184,7 @@ def manage(request):
         if len(train) > 0:
             train = train[0]
 
-            train_dir = "%s/train/%s" % (g_config.storageDir, train.code)
+            train_dir = os.path.join(g_config.storageDir, "train", train.code)
             train_best_model_filepath = os.path.join(train_dir, "train/weights/best.pt")
             if not os.path.exists(train_best_model_filepath):
                 train_best_model_filepath = ""
@@ -219,7 +219,7 @@ def api_postDel(request):
                     g_logger.error("del_sql=%s"%del_sql)
 
                 # 训练根目录
-                train_dir = "%s/train/%s" % (g_config.storageDir, train.code)
+                train_dir = os.path.join(g_config.storageDir, "train", train.code)
                 try:
                     if os.path.exists(train_dir):
                         shutil.rmtree(train_dir)
@@ -288,7 +288,7 @@ def api_postTaskCreateDatasets(request):
         if len(samples) < 50:
             raise Exception("标注样本数量不能低于50")
 
-        train_dir = "%s/train/%s" % (g_config.storageDir, train.code)
+        train_dir = os.path.join(g_config.storageDir, "train", train.code)
         train_datasets_dir = os.path.join(train_dir, "datasets")
         if os.path.exists(train_datasets_dir):
             shutil.rmtree(train_datasets_dir)
@@ -322,7 +322,7 @@ def api_postTaskCreateDatasets(request):
             new_filename = __sample["new_filename"]
             if new_filename.endswith(".jpg"):
                 new_filename_prefix = new_filename[0:-4]
-                src_image_filepath = "%s/task/%s/sample/%s" % (g_config.storageDir, task.code, new_filename)
+                src_image_filepath = os.path.join(g_config.storageDir, "task", task.code, "sample", new_filename)
 
                 if os.path.exists(src_image_filepath):
 
@@ -418,7 +418,7 @@ def api_postTaskStartTrain(request):
                 raise Exception("训练集路径不存在！")
 
             # 训练根目录
-            train_dir = "%s/train/%s" % (g_config.storageDir, train.code)
+            train_dir = os.path.join(g_config.storageDir, "train", train.code)
             if not os.path.exists(train_dir):
                 os.makedirs(train_dir)
             train_log_filepath = os.path.join(train_dir, "train.log") # 训练日志
@@ -569,7 +569,7 @@ def api_getTrainLog(request):
         task = Task.objects.filter(code=task_code)
         if len(task) > 0:
             task = task[0]
-            train_dir = "%s/train/%s" % (g_config.storageDir, train_code)
+            train_dir = os.path.join(g_config.storageDir, "train" , train_code)
             train_log_filepath = os.path.join(train_dir, "train.log")
             if os.path.exists(train_log_filepath):
                 f = open(train_log_filepath, "r")


### PR DESCRIPTION
## 改动内容
将部分使用字符串格式化（如 "%s/train/%s" % (g_config.storageDir, train.code)）进行路径拼接的地方，替换为使用 os.path.join 方法

## 改动原因
原代码在 Windows 下可能因硬编码 / 导致路径错误（如 C:\data/train/... 混合斜杠）
