### PR TITLE
使用os.path.join代替硬编码路径分隔符

### DIFF
--- a/app/views/TrainTestView.py
+++ b/app/views/TrainTestView.py
@@ -64,7 +64,7 @@ def api_postAdd(request):
             if not os.path.exists(train_dir):
                 os.makedirs(train_dir)
 
-            train_best_model_filepath = os.path.join(train_dir, "train/weights/best.pt")
+            train_best_model_filepath = os.path.join(train_dir, "train", "weights", "best.pt")
             if not os.path.exists(train_best_model_filepath):
                 raise Exception("该训练任务暂无模型！")
 

--- a/app/views/TrainView.py
+++ b/app/views/TrainView.py
@@ -185,7 +185,7 @@ def manage(request):
             train = train[0]
 
             train_dir = os.path.join(g_config.storageDir, "train", train.code)
-            train_best_model_filepath = os.path.join(train_dir, "train/weights/best.pt")
+            train_best_model_filepath = os.path.join(train_dir, "train", "weights", "best.pt")
             if not os.path.exists(train_best_model_filepath):
                 train_best_model_filepath = ""
 


### PR DESCRIPTION
将训练模块中的
os.path.join(train_dir, "train/weights/best.pt")
替换为
os.path.join(train_dir, "train", "weights", "best.pt")